### PR TITLE
Work around node segfault

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start": "react-scripts start",
     "test": "yarn test-chain && yarn test-app",
     "test-app": "react-scripts test --passWithNoTests",
-    "test-chain": "ts-mocha --recursive --extension ts --require esm"
+    "test-chain": "ts-mocha --recursive --extension ts --require esm || ([ $? -eq 139 ] && echo 'Segfault')"
   },
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",


### PR DESCRIPTION
## Description

Node started segfaulting after 2020-11-25, I believe due to a native dependency of Ganache. Until this is resolved, ignore the segfault exit code.

Segfaults were still observed today (2021-01-08) without this commit.

## Related PRs

Tests were introduced in https://github.com/peak3d/wolves.finance/pull/4. Currently we don't invoke ganache, but the subsequent PRs will.

## How has this been tested?

Example broken build: https://github.com/juztamau5/wolves.finance/runs/1671367884?check_suite_focus=true

This commit was authored on 2020-12-04. Since then, I've observed no builds failing due to a segfault when this commit is included.