### PR TITLE
[SOL][Presale] Fix receive ETH (reentrancy)

### DIFF
--- a/contracts/src/crowdsale/Crowdsale.sol
+++ b/contracts/src/crowdsale/Crowdsale.sol
@@ -205,7 +205,16 @@ contract Crowdsale is Context, ReentrancyGuard, AddressBook {
    * buyTokens directly when purchasing tokens from a contract.
    */
   receive() external payable {
-    buyTokens(_msgSender());
+    // A payable receive() function follows the OpenZeppelin strategy, in which
+    // it is designed to buy tokens.
+    //
+    // However, because we call out to uniV2Router from the crowdsale contract,
+    // re-imbursement of ETH from UniswapV2Pair must not by tokens.
+    //
+    // Instead it must be payed to this contract in a first step and will than
+    // be transferred to the recipient in _addLiquidity().
+    //
+    if (_msgSender() != address(uniV2Router)) buyTokens(_msgSender());
   }
 
   /**

--- a/contracts/src/token/Token.sol
+++ b/contracts/src/token/Token.sol
@@ -206,6 +206,7 @@ contract WowsToken is ERC20Capped, AccessControl, IRewardHandler, AddressBook {
     // Minters are always allowed to transfer
     require(
       hasRole(MINTER_ROLE, sender) ||
+        hasRole(MINTER_ROLE, recipient) ||
         (_checkForUniV2Pair(sender) && _checkForUniV2Pair(recipient)),
       'Only minters and != pairs'
     );

--- a/src/config/addresses.ts
+++ b/src/config/addresses.ts
@@ -13,11 +13,23 @@ const addresses = {
     presale: '0x0000000000000000000000000000000000000000',
     univ2Pool: '0x0000000000000000000000000000000000000000',
   },
+  3: {
+    //ropsten
+    token: '0x2AEeaEaC18aD6814b1e95F09f55080dDa942B6b9',
+    presale: '0x45e77d9CFd7C16567916fFc840A25Da4071D471e',
+    univ2Pool: '0xbA81D1f3a909697eE82054b82F5975a25d0aB9e4',
+  },
   4: {
     //rinkeby
-    token: '0x14a2706903Cb41444fe3C748a8C32372d608bEb5',
-    presale: '0xB9cF9d90d39Ee86f08bC70b01d23Afe2524F2112',
-    univ2Pool: '0xC2c4e4B52a042Eb79438991BB1632cc8115b6006',
+    token: '0x236D217058b5bf3bE927976Fc4dC87E9C13E09cD',
+    presale: '0x17Bed1e9e69777114D5aE70A725B2Cccd137890A',
+    univ2Pool: '0xb9d526E105a8E28b2267768dbb2016Ee6b2B4a2B',
+  },
+  97: {
+    //Binance SC Test
+    token: '0x2AEeaEaC18aD6814b1e95F09f55080dDa942B6b9',
+    presale: '0x45e77d9CFd7C16567916fFc840A25Da4071D471e',
+    univ2Pool: '0xF65501Cc604a719F85EfAc1Be39f6E32472CFEc9',
   },
   1337: {
     //private

--- a/src/stores/store.tsx
+++ b/src/stores/store.tsx
@@ -352,8 +352,12 @@ class Store {
     switch (this.chainId) {
       case 1:
         return addresses[1];
+      case 3:
+        return addresses[3];
       case 4:
         return addresses[4];
+      case 97:
+        return addresses[97];
       case 1337:
         return addresses[1337];
       default:


### PR DESCRIPTION
Using UniswapRouter::addLiquidityETH in Crowdsale could lead to re-imbursment of ETH from UniswapV2Pair to Crowdsale contract.
Because receive() payable is designed to buy tokens, we run in a re-entrancy case.

Fix: don't buy tokens if receive() is called from UniswpV2Router.