### PR TITLE
[UI] Fix smalldiff adjustment in stake

### DIFF
--- a/src/stores/store.tsx
+++ b/src/stores/store.tsx
@@ -646,8 +646,8 @@ class Store {
       this.address
     );
     if (
-      (available > stakeAmount && available.sub(stakeAmount).lt(1000)) ||
-      (available < stakeAmount && stakeAmount.sub(available).lt(1000))
+      (available.gt(stakeAmount) && available.sub(stakeAmount).lt(1000)) ||
+      (available.lt(stakeAmount) && stakeAmount.sub(available).lt(1000))
     )
       stakeAmount = available;
 


### PR DESCRIPTION
[UI]
the comparision of BigNumbers with < > operator doesn't work as expected while looking for minimal differences between the amount to stake and the available amount. This leads to staking available amount even amount to stake is much smaller.

Fix is to use BigNumber operators