### PR TITLE
[UI] prevent stake > available / add link to uniswap

### DIFF
--- a/src/components/stake/stake.css
+++ b/src/components/stake/stake.css
@@ -104,3 +104,11 @@
   margin: 3px;
   flex-grow: 1;
 }
+
+.stake-links {
+  width: 100%;
+}
+
+.stake-links a {
+  color: var(--wolves-blue-dk);
+}

--- a/src/components/stake/stake.tsx
+++ b/src/components/stake/stake.tsx
@@ -135,7 +135,7 @@ class Stake extends Component<STAKEPROPS, STAKESTATE> {
       connected ? s : t('header.connectWallet').toString();
 
     return (
-      <div className="stake-main">
+      <div className="stake-main tk-grotesk-lightbold">
         <div className="stake-container">
           <h1>{t('stake.welcome')}</h1>
           <StakeInfo />
@@ -183,6 +183,18 @@ class Stake extends Component<STAKEPROPS, STAKESTATE> {
                   disabled={!connected}
                   onClick={(e) => this.onTransaction(STAKE_EXIT)}
                 />
+              </div>
+              <div className="stake-links">
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href={
+                    'https://app.uniswap.org/#/add/ETH/' +
+                    StoreClasses.store._getTokenContractAddress()
+                  }
+                >
+                  Get liquidity pair token on Uniswap
+                </a>
               </div>
             </div>
           </div>

--- a/src/stores/store.tsx
+++ b/src/stores/store.tsx
@@ -115,13 +115,15 @@ class Store {
   presaleContractRO: ethers.Contract | null = null;
   stakeContractRO: ethers.Contract | null = null;
   uniDaiWethPairContractRO: ethers.Contract | null = null;
+
+  static nullAddress = '0x0000000000000000000000000000000000000000';
+
   /* Misc */
   networkName = 'mainnet';
   chainId = 0;
   address = '';
+  tokenContractAddress = Store.nullAddress;
   assets = {};
-
-  static nullAddress = '0x0000000000000000000000000000000000000000';
 
   constructor() {
     this.web3Modal = new Web3Modal({
@@ -402,6 +404,7 @@ class Store {
     const chainAddresses = this._getChainAddresses();
 
     if (chainAddresses) {
+      this.tokenContractAddress = chainAddresses.token;
       this.presaleContractRO = new ethers.Contract(
         chainAddresses.presale,
         CrowdsaleAbi,
@@ -420,6 +423,8 @@ class Store {
           provider
         );
       }
+    } else {
+      this.tokenContractAddress = Store.nullAddress;
     }
   }
 
@@ -550,6 +555,10 @@ class Store {
     }
   };
 
+  _getTokenContractAddress() {
+    return this.tokenContractAddress;
+  }
+
   _getPresaleContractAddress() {
     return this.presaleContractRO?.address;
   }
@@ -666,6 +675,14 @@ class Store {
       (available.lt(stakeAmount) && stakeAmount.sub(available).lt(1000))
     )
       stakeAmount = available;
+
+    if (stakeAmount > available) {
+      emitter.emit(STAKE_ADD, {
+        status: 'error',
+        errorMessage: 'Insufficient LP token.',
+      } as StatusResult);
+      return;
+    }
 
     try {
       const allowance = await this.lPContract.allowance(


### PR DESCRIPTION
[UI]
- When trying to stake with an amount > available amount of LP token, the value is approved on mainnet which cost gas.
We now validate the input against amount in the wallet, and alert early without spending gas.

- Add a link to our LP pair to make sure users hit the correct pair.