### PR TITLE
[SOL] Optimize for 1,000 runs to lessen bytecode size

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -48,7 +48,7 @@ const config = {
           evmVersion: 'berlin',
           optimizer: {
             enabled: true,
-            runs: 1000000,
+            runs: 1000,
             details: {
               yul: true,
               deduplicate: true,


### PR DESCRIPTION
According to the documentation:

    By default, the optimizer will optimize the contract assuming it
    is called 200 times across its lifetime.

    If you want the initial contract deployment to be cheaper and the
    later function executions to be more expensive, set it to
    --optimize-runs=1.

    If you expect many transactions and do not care for higher deployment
    cost and output size, set --optimize-runs to a high number.

The initial value of 1,000,000 was selected by searching for lots of Hardhat projects and using the maximum run count I discovered.

A value of 10,000 successfully allows our contracts to now be deployed. I chose the value of 1,000 instead because enormously high values lead to no apparent benefit.
    
## How has this been tested?

Before, warning was:

    contracts/src/token/TradeFloor.sol:29:1: Warning: Contract code size exceeds 24576 bytes

After, warning is gone and the large contracts can be deployed.