### PR TITLE
[SOL] Change single-token callbacks to batch versions

### DIFF
--- a/contracts/src/cfolio/TradeFloorClientLP.sol
+++ b/contracts/src/cfolio/TradeFloorClientLP.sol
@@ -132,16 +132,16 @@ contract TradeFloorClientLP is ITradefloorClient {
   /**
    * @dev Called from Tradefloor of tokens have been transfered.
    *
-   * See {IMinterCallback-_onTransferFrom}.
+   * See {IMinterCallback-_onBatchTransferFrom}.
    *
    * We have to transfer / remove reward shares here
    * depending if from / to is a c-folio or not
    */
-  function onTransferFrom(
+  function onBatchTransferFrom(
     address from,
     address to,
-    uint256 tokenId,
-    uint256 amount
+    uint256[] memory tokenIds,
+    uint256[] memory amounts
   ) external override {
     // TODO: transfer elements from -> to
     // -> remove / add reward share in case from/to is c-folio
@@ -150,24 +150,31 @@ contract TradeFloorClientLP is ITradefloorClient {
   /**
    * @dev Called from Tradefloor if tokens have been burned.
    *
-   * See {IMinterCallback-_onBurn}.
+   * See {IMinterCallback-_onBatchBurn}.
    *
    * We have to remove reward shares here, and payout underlying
    * assets. Pending rewards can be left inside SFT.
    */
-  function onBurn(
+  function onBatchBurn(
     address recipient,
     address, /* account*/
-    uint256 tokenId,
-    uint256 amount
+    uint256[] memory tokenIds,
+    uint256[] memory amounts
   ) external override {
+    // Validate sender
     require(msg.sender == address(tradeFloor), 'onBurn: only TF');
-    require(tokenId == tradeFloorTokenId, 'onBurn: wrong tokenId');
 
-    // Transfer lpTokens back to to recipient
-    stakingToken.transferFrom(address(this), recipient, amount);
+    for (uint256 i = 0; i < tokenIds.length; ++i) {
+      uint256 tokenId = tokenIds[i];
+      uint256 amount = amounts[i];
 
-    // TODO: handle rewards
+      require(tokenId == tradeFloorTokenId, 'onBurn: wrong tokenId');
+
+      // Transfer lpTokens back to to recipient
+      stakingToken.transferFrom(address(this), recipient, amount);
+
+      // TODO: handle rewards
+    }
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/contracts/src/token/TradeFloor.sol
+++ b/contracts/src/token/TradeFloor.sol
@@ -300,7 +300,7 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
     tokenIds[0] = tokenId;
     values[0] = value;
 
-    _onBurn(account, tokenIds, values);
+    _onBatchBurn(account, tokenIds, values);
   }
 
   /**
@@ -317,7 +317,7 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
 
     // Call parent
     super.burnBatch(account, tokenIds, values);
-    _onBurn(account, tokenIds, values);
+    _onBatchBurn(account, tokenIds, values);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -342,14 +342,19 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
     super.safeTransferFrom(from, to, tokenId, amount, data);
 
     if ((tokenId >> 64) == 0) {
+      // Update state
       _relinkOwner(from, to, uint64(tokenId));
-      // Invoke callback
     } else {
       // Look up minter
       address minter = _tokenIdToMinter[tokenId];
       require(minter != address(0), 'Invalid minter for token');
 
-      IMinterCallback(minter).onTransferFrom(from, to, tokenId, amount);
+      // Invoke callback
+      uint256[] memory tokenIds = new uint256[](1);
+      uint256[] memory amounts = new uint256[](1);
+      tokenIds[0] = tokenId;
+      amounts[0] = amount;
+      IMinterCallback(minter).onBatchTransferFrom(from, to, tokenIds, amounts);
     }
   }
 
@@ -371,17 +376,32 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
     // Call parent
     super.safeBatchTransferFrom(from, to, tokenIds, amounts, data);
 
-    // Invoke callbacks
-    for (uint256 i = 0; i < tokenIds.length; i++) {
-      uint256 tokenId = tokenIds[i];
-      if ((tokenId >> 64) == 0) {
-        _relinkOwner(from, to, uint64(tokenId));
-      } else {
-        address minter = _tokenIdToMinter[tokenId];
-        require(minter != address(0), 'Invalid minter for token');
-
-        IMinterCallback(minter).onTransferFrom(from, to, tokenId, amounts[i]);
+    if (tokenIds.length > 0) {
+      // Validate parameters
+      address firstMinter = _tokenIdToMinter[tokenIds[0]];
+      require(firstMinter != address(0), 'Invalid minter of tokens');
+      for (uint256 i = 1; i < tokenIds.length; i++) {
+        require(
+          firstMinter == _tokenIdToMinter[tokenIds[i]],
+          'All tokens must have same minter'
+        );
       }
+
+      // Update state
+      for (uint256 i = 0; i < tokenIds.length; i++) {
+        uint256 tokenId = tokenIds[i];
+        if ((tokenId >> 64) == 0) {
+          _relinkOwner(from, to, uint64(tokenId));
+        }
+      }
+
+      // Invoke callback
+      IMinterCallback(firstMinter).onBatchTransferFrom(
+        from,
+        to,
+        tokenIds,
+        amounts
+      );
     }
   }
 
@@ -549,7 +569,7 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
     tokenIds[0] = tokenId;
     uint256[] memory amounts = new uint256[](1);
     amounts[0] = amount;
-    _onTokensReceived(from, tokenIds, amounts);
+    _onBatchTokensReceived(from, tokenIds, amounts);
 
     return super.onERC1155Received(operator, from, tokenId, amount, data);
   }
@@ -561,7 +581,7 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
     uint256[] memory amounts,
     bytes memory data
   ) public override returns (bytes4) {
-    _onTokensReceived(from, tokenIds, amounts);
+    _onBatchTokensReceived(from, tokenIds, amounts);
 
     // This contract supports safe ERC-1155 transfers
     return
@@ -657,33 +677,46 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
   // Internal details
   //////////////////////////////////////////////////////////////////////////////
 
-  function _onBurn(
+  /**
+   * @dev Handle a batch burn
+   *
+   * Precondition: All tokens must have the same minter.
+   *
+   * @param account The account owning the tokens
+   * @param tokenIds The token IDs being burned
+   * @param amounts The amounts of tokens being burned
+   */
+  function _onBatchBurn(
     address account,
     uint256[] memory tokenIds,
     uint256[] memory amounts
   ) private {
-    // Count tokenIds < 64 Bit
     uint256 numStakes = 0;
 
-    // Invoke callbacks / count SFT's
     for (uint256 i = 0; i < tokenIds.length; i++) {
       uint256 tokenId = tokenIds[i];
 
-      // Unstake SFT on burn
+      // Count tokenIds < 64 Bit
       if ((tokenId >> 64) == 0) {
         ++numStakes;
-        _relinkOwner(account, address(0), uint64(tokenId));
-      } else {
-        address minter = _tokenIdToMinter[tokenId];
-        require(minter != address(0), 'Token has no minter');
-
-        IMinterCallback(minter).onBurn(
-          _msgSender(),
-          account,
-          tokenId,
-          amounts[i]
-        );
       }
+
+      // Unstake SFT on burn
+      if ((tokenId >> 64) == 0) {
+        _relinkOwner(account, address(0), uint64(tokenId));
+      }
+    }
+
+    // Invoke callbacks
+    if (tokenIds.length > 0) {
+      address minter = _tokenIdToMinter[tokenIds[0]];
+
+      IMinterCallback(minter).onBatchBurn(
+        _msgSender(),
+        account,
+        tokenIds,
+        amounts
+      );
     }
 
     // Unstake SFTs if required
@@ -698,10 +731,12 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
           unstakeAmounts[numStakes] = 1;
         }
       }
+
       // Load address
       IERC1155 sftContract =
         IERC1155(_addressRegistry.getRegistryEntry(AddressBook.SFT_HOLDER));
 
+      // Update state
       sftContract.safeBatchTransferFrom(
         address(this),
         _msgSender(),
@@ -739,7 +774,7 @@ contract TradeFloor is WOWSMinterPauser, ERC1155Holder {
   /**
    * @dev SFT Token arrived, provide a NFT
    */
-  function _onTokensReceived(
+  function _onBatchTokensReceived(
     address from,
     uint256[] memory tokenIds,
     uint256[] memory amounts

--- a/contracts/src/token/WOWSCryptofolio.sol
+++ b/contracts/src/token/WOWSCryptofolio.sol
@@ -190,7 +190,7 @@ contract WOWSCryptofolio is ERC1155Holder, IWOWSCryptofolio {
     amounts[0] = amount;
 
     // Update state
-    _onTokensReceived(tokenIds, amounts);
+    _onBatchTokensReceived(tokenIds, amounts);
 
     // This contract supports safe ERC-1155 transfers
     return super.onERC1155Received(operator, from, tokenId, amount, data);
@@ -204,7 +204,7 @@ contract WOWSCryptofolio is ERC1155Holder, IWOWSCryptofolio {
     bytes memory data
   ) public override returns (bytes4) {
     // Update state
-    _onTokensReceived(tokenIds, amounts);
+    _onBatchTokensReceived(tokenIds, amounts);
 
     // This contract supports safe ERC-1155 transfers
     return
@@ -221,7 +221,7 @@ contract WOWSCryptofolio is ERC1155Holder, IWOWSCryptofolio {
    * This function is only allowed to be called from one of our pseudo
    * TokenReceiver contracts.
    */
-  function _onTokensReceived(
+  function _onBatchTokensReceived(
     uint256[] memory tokenIds,
     uint256[] memory amounts
   ) internal {

--- a/contracts/src/token/interfaces/IMinterCallback.sol
+++ b/contracts/src/token/interfaces/IMinterCallback.sol
@@ -9,36 +9,37 @@
 pragma solidity >=0.7.0 <0.8.0;
 
 /**
- * @dev Interface to receive callbacks when minted tokens are burnt
+ * @dev Interface to receive callbacks when minted tokens are transfered or
+ * burnt
  */
 interface IMinterCallback {
   /**
-   * @dev Called when a token minted by a minter is transferred
+   * @dev Called when tokens minted by a minter are transferred
    *
    * @param from The account sending the token
    * @param to The account receiving the token
-   * @param tokenId The ERC-1155 token ID
-   * @param amount The amount of tokens transfered
+   * @param tokenIds The ERC-1155 token IDs
+   * @param amounts The amounts of tokens being transfered
    */
-  function onTransferFrom(
+  function onBatchTransferFrom(
     address from,
     address to,
-    uint256 tokenId,
-    uint256 amount
+    uint256[] memory tokenIds,
+    uint256[] memory amounts
   ) external;
 
   /**
-   * @dev Called when a token minted by a minter is burned
+   * @dev Called when tokens minted by a minter are burned
    *
    * @param recipient The account used for payback investments
    * @param account The account owning the token
-   * @param tokenId The ERC-1155 token ID
-   * @param amount The amount of tokens burned
+   * @param tokenIds The ERC-1155 token IDs
+   * @param amounts The amounts of tokens being burned
    */
-  function onBurn(
+  function onBatchBurn(
     address recipient,
     address account,
-    uint256 tokenId,
-    uint256 amount
+    uint256[] memory tokenIds,
+    uint256[] memory amounts
   ) external;
 }

--- a/contracts/test/TestStakingContract.sol
+++ b/contracts/test/TestStakingContract.sol
@@ -26,23 +26,23 @@ contract TestStakingContract is IMinterCallback, ERC1155Holder {
   //////////////////////////////////////////////////////////////////////////////
 
   /**
-   * @dev See {IMinterCallback-onTransferFrom}.
+   * @dev See {IMinterCallback-onBatchTransferFrom}.
    */
-  function onTransferFrom(
+  function onBatchTransferFrom(
     address from,
     address to,
-    uint256 tokenId,
-    uint256 amount
+    uint256[] memory tokenIds,
+    uint256[] memory amounts
   ) public override {}
 
   /**
-   * @dev See {IMinterCallback-onBurn}.
+   * @dev See {IMinterCallback-onBatchBurn}.
    */
-  function onBurn(
+  function onBatchBurn(
     address recipient,
     address account,
-    uint256 tokenId,
-    uint256 amount
+    uint256[] memory tokenIds,
+    uint256[] memory amounts
   ) public override {}
 
   //////////////////////////////////////////////////////////////////////////////

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -48,7 +48,7 @@ const config = {
           evmVersion: 'berlin',
           optimizer: {
             enabled: true,
-            runs: 10000,
+            runs: 1000,
             details: {
               yul: true,
               deduplicate: true,


### PR DESCRIPTION
## Description

I've reversed a decision I made earlier. In the IMinterCallback, I used single versions instead of batch versions. This was because batch versions can only be used for a single minter, and I chose to lessen code size and avoid testing batch transfer/burns for a single minter.

Now, we take the hit and verify all batch operations have the same minter. The single callbacks are updated to batches. This makes the code more general and gas-friendly from a scalability standpoint. We could optimize gas usage further, and provide both single *and* batch callbacks, but I would argue for code simplicity and only include the batch variants.