### PR TITLE
[SOL] Optimize for 1,000 runs to lessen bytecode size

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -48,7 +48,7 @@ const config = {
           evmVersion: 'berlin',
           optimizer: {
             enabled: true,
-            runs: 10000,
+            runs: 1000,
             details: {
               yul: true,
               deduplicate: true,


### PR DESCRIPTION
## Description

Same fix as https://github.com/wolvesofwallstreet/wolves.finance/pull/68, applied to the `lock` branch. An undocumented fix similar to this was made, so the commit can't be cherry-picked due to a conflict.

According to the documentation:

    By default, the optimizer will optimize the contract assuming it
    is called 200 times across its lifetime.

    If you want the initial contract deployment to be cheaper and the
    later function executions to be more expensive, set it to
    --optimize-runs=1.

    If you expect many transactions and do not care for higher deployment
    cost and output size, set --optimize-runs to a high number.

## How has this been tested?

Warning was:

    contracts/src/token/TradeFloor.sol:29:1: Warning: Contract code size exceeds 24576 bytes

CI was left in a broken state, so the fix can't be verified.