### PR TITLE
Extend TradeFloorClientLP tests and add gas costs

### DIFF
--- a/test/web3/test-trade-floor.ts
+++ b/test/web3/test-trade-floor.ts
@@ -32,6 +32,24 @@ chai.use(solidity);
 // Path to generated address registry file
 const GENERATED_ADDRESSES = `${__dirname}/../../src/config/generated-addresses.json`;
 
+// The following gas prices are available
+//
+//   - 'SLOW'
+//   - 'AVERAGE'
+//   - 'FAST'
+//   - 'FASTEST'
+//
+const GAS_PRICE = 'AVERAGE';
+
+// Current price API URL
+const CURRENT_PRICE_URL =
+  'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=ethereum';
+
+// Gas estimator API URL
+// TODO: Move API key to GitHub Actions secret
+const GAS_ESTIMATOR_URL =
+  'https://data-api.defipulse.com/api/v1/egs/api/ethgasAPI.json?api-key=53be2a60f8bc0bb818ad161f034286d709a9c4ccb1362054b0543df78e27';
+
 // Helper function
 function toWei(n: number, decimals = 18) {
   const parsed = typeof n === 'number' ? n.toFixed(decimals) : n;
@@ -147,6 +165,50 @@ describe('TradeFloorClientLP', function () {
   const tradeFloorTokenIdBoi = ethers.BigNumber.from('0x10000000000000000');
   const tradeFloorTokenIdWolf = ethers.BigNumber.from('0x10000000000000001');
 
+  // Lazily-initialized variables
+  let ethUsd = 0;
+  let gasPrice = 0;
+
+  // Helper function
+  async function toUsd(eth: number): Promise<number> {
+    if (ethUsd === 0) {
+      // Query current price API
+      const response = await fetch(CURRENT_PRICE_URL);
+
+      // Parse response
+      const responseJson = await response.json();
+      if (responseJson) {
+        ethUsd = responseJson[0].current_price;
+      }
+    }
+
+    return parseFloat((eth * ethUsd).toFixed(2));
+  }
+
+  // Helper function
+  async function getGasPrice() {
+    if (gasPrice === 0) {
+      // Lookup table for JSON keys
+      const JSON_KEY = {
+        SLOW: 'safeLow',
+        AVERAGE: 'average',
+        FAST: 'fast',
+        FASTEST: 'fastest',
+      };
+
+      // Query current price API
+      const response = await fetch(GAS_ESTIMATOR_URL);
+
+      // Parse response
+      const responseJson = await response.json();
+      if (responseJson) {
+        gasPrice = (responseJson[JSON_KEY[GAS_PRICE]] * 1e9) / 10;
+      }
+    }
+
+    return gasPrice;
+  }
+
   before(async function () {
     this.timeout(60 * 1000);
 
@@ -155,6 +217,13 @@ describe('TradeFloorClientLP', function () {
 
     // A single fixture is used for the test suite
     contracts = await setupTest();
+
+    // Query API providers
+    const ethUsd = await toUsd(1);
+    const gasPrice = await getGasPrice();
+
+    console.log(`ETH price is $${ethUsd}`);
+    console.log(`Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
   });
 
   it('should approve spending WOWS', async function () {
@@ -197,6 +266,19 @@ describe('TradeFloorClientLP', function () {
       wowsTokenIdBoi, // Token ID
       level1Price // Price
     );
+
+    // Log gas cost
+    const receipt = await (await tx).wait();
+    const gasUsedGwei = receipt.gasUsed;
+    const gasCost =
+      gasUsedGwei
+        .mul(await getGasPrice())
+        .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
+    console.log(
+      `Mint boi gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+        gasCost
+      )})`
+    );
   });
 
   it('should mint wolf SFT', async function () {
@@ -214,6 +296,19 @@ describe('TradeFloorClientLP', function () {
       marketingWallet.address, // Recipient
       wowsTokenIdWolf, // Token ID
       level1Price // Price
+    );
+
+    // Log gas cost
+    const receipt = await (await tx).wait();
+    const gasUsedGwei = receipt.gasUsed;
+    const gasCost =
+      gasUsedGwei
+        .mul(await getGasPrice())
+        .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
+    console.log(
+      `Mint wolf gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+        gasCost
+      )})`
     );
   });
 
@@ -406,6 +501,19 @@ describe('TradeFloorClientLP', function () {
       tradeFloorClientLP.address, // spender
       lpBalance // balance
     );
+
+    // Log gas cost
+    const receipt = await (await tx).wait();
+    const gasUsedGwei = receipt.gasUsed;
+    const gasCost =
+      gasUsedGwei
+        .mul(await getGasPrice())
+        .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
+    console.log(
+      `Approve LP gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+        gasCost
+      )})`
+    );
   });
 
   it('should increase possible token IDs', async function () {
@@ -496,6 +604,19 @@ describe('TradeFloorClientLP', function () {
     );
     chai.expect(idsLength).to.equal(1);
     chai.expect(tokenIds[0]).to.equal(tradeFloorTokenIdWolf);
+
+    // Log gas cost
+    const receipt = await (await tx).wait();
+    const gasUsedGwei = receipt.gasUsed;
+    const gasCost =
+      gasUsedGwei
+        .mul(await getGasPrice())
+        .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
+    console.log(
+      `Deposit LP gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+        gasCost
+      )})`
+    );
   });
 
   it('should attach the trade floor proxy', async function () {
@@ -545,6 +666,19 @@ describe('TradeFloorClientLP', function () {
     );
     chai.expect(idsLength).to.equal(1);
     chai.expect(tokenIds[0]).to.equal(tradeFloorTokenIdWolf);
+
+    // Log gas cost
+    const receipt = await (await tx).wait();
+    const gasUsedGwei = receipt.gasUsed;
+    const gasCost =
+      gasUsedGwei
+        .mul(await getGasPrice())
+        .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
+    console.log(
+      `Burn LP NFT gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+        gasCost
+      )})`
+    );
   });
 
   it('should burn almost the other half of the LP NFT', async function () {

--- a/test/web3/test-trade-floor.ts
+++ b/test/web3/test-trade-floor.ts
@@ -127,6 +127,26 @@ describe('TradeFloorClientLP', function () {
   let marketingWallet: SignerWithAddress;
   let contracts: any;
 
+  let cryptofolioAddressBoi: string;
+  let cryptofolioAddressWolf: string;
+
+  let cryptofolioContractBoi: ethers.Contract;
+  let cryptofolioContractWolf: ethers.Contract;
+
+  let tradeFloorProxyInstance: ethers.Contract;
+
+  // Test parameters
+  const level1Price = '3000000000000000000';
+  const lpBalance = ethers.BigNumber.from('12000000000000000000'); // 12 UNI-V2 LP tokens
+  const levelBoi = 1;
+  const cardIdBoi = 2;
+  const levelWolf = 5;
+  const cardIdWolf = 2;
+  const wowsTokenIdBoi = ethers.BigNumber.from('0x01020000');
+  const wowsTokenIdWolf = ethers.BigNumber.from('0x05020000');
+  const tradeFloorTokenIdBoi = ethers.BigNumber.from('0x10000000000000000');
+  const tradeFloorTokenIdWolf = ethers.BigNumber.from('0x10000000000000001');
+
   before(async function () {
     this.timeout(60 * 1000);
 
@@ -137,31 +157,37 @@ describe('TradeFloorClientLP', function () {
     contracts = await setupTest();
   });
 
-  it('should mint a WOWS SFT', async function () {
+  it('should approve spending WOWS', async function () {
     this.timeout(60 * 1000);
 
-    const { tokenContract, sftHolderContract, sftMinterContract } = contracts;
-
-    // Test parameters
-    const levelBoi = 1;
-    const cardIdBoi = 2;
-    const levelWolf = 5;
-    const cardIdWolf = 2;
-    const wowsTokenIdBoi = ethers.BigNumber.from('0x01020000');
-    const wowsTokenIdWolf = ethers.BigNumber.from('0x05020000');
-    const level1Price = '3000000000000000000';
+    const { tokenContract, sftMinterContract } = contracts;
 
     // Approve SFT minter spending WOWS
-    let tx = tokenContract.approve(
+    const tx = tokenContract.approve(
       sftMinterContract.address,
       ethers.BigNumber.from(
         '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
       )
     );
-    await chai.expect(tx).to.not.be.reverted;
+    await chai
+      .expect(tx)
+      .to.emit(tokenContract, 'Approval')
+      .withArgs(
+        marketingWallet.address,
+        sftMinterContract.address,
+        ethers.BigNumber.from(
+          '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+        )
+      );
+  });
+
+  it('should mint boi SFT', async function () {
+    this.timeout(60 * 1000);
+
+    const { sftMinterContract } = contracts;
 
     // Mint the Bois WOWS SFT
-    tx = sftMinterContract.mintWowsSFT(
+    const tx = sftMinterContract.mintWowsSFT(
       marketingWallet.address,
       levelBoi,
       cardIdBoi
@@ -171,9 +197,15 @@ describe('TradeFloorClientLP', function () {
       wowsTokenIdBoi, // Token ID
       level1Price // Price
     );
+  });
+
+  it('should mint wolf SFT', async function () {
+    this.timeout(60 * 1000);
+
+    const { sftMinterContract } = contracts;
 
     // Mint the Wolf WOWS SFT
-    tx = sftMinterContract.mintWowsSFT(
+    const tx = sftMinterContract.mintWowsSFT(
       marketingWallet.address,
       levelWolf,
       cardIdWolf
@@ -183,6 +215,12 @@ describe('TradeFloorClientLP', function () {
       wowsTokenIdWolf, // Token ID
       level1Price // Price
     );
+  });
+
+  it('should check token ownership', async function () {
+    this.timeout(60 * 1000);
+
+    const { sftHolderContract } = contracts;
 
     // Check the token's ownership (NFT balance is always 1)
     const balanceBoi = await sftHolderContract.balanceOf(
@@ -197,12 +235,24 @@ describe('TradeFloorClientLP', function () {
       wowsTokenIdWolf
     );
     chai.expect(balanceWolf).to.equal(1);
+  });
 
-    // Check the owner's token count
+  it('should check token IDs', async function () {
+    this.timeout(60 * 1000);
+
+    const { sftHolderContract } = contracts;
+
+    // Check the owner's token IDs
     const result = await sftHolderContract.getTokenIds(marketingWallet.address);
     chai.expect(result.length).to.equal(2);
     chai.expect(result[0]).to.equal(wowsTokenIdWolf);
     chai.expect(result[1]).to.equal(wowsTokenIdBoi);
+  });
+
+  it('should query boi token ID', async function () {
+    this.timeout(60 * 1000);
+
+    const { sftHolderContract } = contracts;
 
     // Query the token ID in the SFT contract
     const [
@@ -211,6 +261,12 @@ describe('TradeFloorClientLP', function () {
     ] = await sftHolderContract.getTokenData(wowsTokenIdBoi);
     chai.expect(mintTimestampBoi).to.not.equal(0);
     chai.expect(tokenLevelBoi).to.equal(levelBoi);
+  });
+
+  it('should query wolf token ID', async function () {
+    this.timeout(60 * 1000);
+
+    const { sftHolderContract } = contracts;
 
     // Query the token ID in the SFT contract
     const [
@@ -219,9 +275,15 @@ describe('TradeFloorClientLP', function () {
     ] = await sftHolderContract.getTokenData(wowsTokenIdWolf);
     chai.expect(mintTimestampWolf).to.not.equal(0);
     chai.expect(tokenLevelWolf).to.equal(levelWolf);
+  });
+
+  it('should get addresses of clone contracts', async function () {
+    this.timeout(60 * 1000);
+
+    const { sftHolderContract } = contracts;
 
     // Get the address of the clone contract
-    const cryptofolioAddressBoi = await sftHolderContract.tokenIdToAddress(
+    cryptofolioAddressBoi = await sftHolderContract.tokenIdToAddress(
       wowsTokenIdBoi
     );
     chai.expect(cryptofolioAddressBoi).to.be.properAddress;
@@ -230,7 +292,7 @@ describe('TradeFloorClientLP', function () {
       .to.not.equal('0x0000000000000000000000000000000000000000');
 
     // Get the address of the clone contract
-    const cryptofolioAddressWolf = await sftHolderContract.tokenIdToAddress(
+    cryptofolioAddressWolf = await sftHolderContract.tokenIdToAddress(
       wowsTokenIdWolf
     );
     chai.expect(cryptofolioAddressWolf).to.be.properAddress;
@@ -239,10 +301,28 @@ describe('TradeFloorClientLP', function () {
       .to.not.equal('0x0000000000000000000000000000000000000000');
   });
 
+  it('should know the token IDs of clone contracts', async function () {
+    this.timeout(60 * 1000);
+
+    const { sftHolderContract } = contracts;
+
+    // Get the token ID of the clone contract
+    const tokenIdBoi = await sftHolderContract.addressToTokenId(
+      cryptofolioAddressBoi
+    );
+    chai.expect(tokenIdBoi).to.equal(wowsTokenIdBoi);
+
+    // Get the token ID of the clone contract
+    const tokenIdWolf = await sftHolderContract.addressToTokenId(
+      cryptofolioAddressWolf
+    );
+    chai.expect(tokenIdWolf).to.equal(wowsTokenIdWolf);
+  });
+
   it('should get LP tokens', async function () {
     this.timeout(60 * 1000);
 
-    const { uniV2PairContract, presaleContract } = contracts;
+    const { presaleContract } = contracts;
 
     //
     // Get LP tokens for the marketing wallet
@@ -279,54 +359,45 @@ describe('TradeFloorClientLP', function () {
     // Finalize the presale
     tx = presaleContract.finalizePresale();
     await chai.expect(tx).to.not.be.reverted;
-
-    // Check wallet balance
-    const lpBalance = await uniV2PairContract.balanceOf(
-      marketingWallet.address
-    );
-    chai
-      .expect(lpBalance)
-      .to.equal(ethers.BigNumber.from('12000000000000000000')); // 12 LP tokens
   });
 
-  it('should stake an LP NFT in the cryptofolio', async function () {
+  it('should check wallet balance', async function () {
     this.timeout(60 * 1000);
 
-    const {
-      uniV2PairContract,
-      sftHolderContract,
-      tradeFloorContract,
-      tradeFloorProxyContract,
-      tradeFloorClientLP,
-    } = contracts;
+    const { uniV2PairContract } = contracts;
 
-    // Test parameters
-    const wowsTokenId = ethers.BigNumber.from('0x05020000');
-    const tradeFloorTokenId = ethers.BigNumber.from('0x10000000000000000');
-
-    // Get the address of the clone contract
-    const cryptofolioAddress = await sftHolderContract.tokenIdToAddress(
-      wowsTokenId
-    );
-    chai.expect(cryptofolioAddress).to.be.properAddress;
-    chai
-      .expect(cryptofolioAddress)
-      .to.not.equal('0x0000000000000000000000000000000000000000');
-
-    // Get wallet balance
-    const lpBalance = await uniV2PairContract.balanceOf(
+    // Check wallet balance
+    const currentLpBalance = await uniV2PairContract.balanceOf(
       marketingWallet.address
     );
+    chai.expect(currentLpBalance).to.equal(lpBalance);
+  });
+
+  it('should instantiate cryptofolio contracts', async function () {
+    this.timeout(60 * 1000);
 
     // Instantiate cryptofolio contract
-    const cryptofolioContract = new ethers.Contract(
-      cryptofolioAddress,
+    cryptofolioContractBoi = new ethers.Contract(
+      cryptofolioAddressBoi,
       WOWSCryptofolioAbi,
       marketingWallet
     );
 
+    // Instantiate cryptofolio contract
+    cryptofolioContractWolf = new ethers.Contract(
+      cryptofolioAddressWolf,
+      WOWSCryptofolioAbi,
+      marketingWallet
+    );
+  });
+
+  it('should approve TFCLP to transfer tokens', async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV2PairContract, tradeFloorClientLP } = contracts;
+
     // Approve TFCLP to transfer our tokens
-    let tx = await uniV2PairContract.approve(
+    const tx = await uniV2PairContract.approve(
       tradeFloorClientLP.address,
       lpBalance
     );
@@ -335,11 +406,70 @@ describe('TradeFloorClientLP', function () {
       tradeFloorClientLP.address, // spender
       lpBalance // balance
     );
+  });
 
-    // Deposit LP tokens
-    tx = tradeFloorClientLP.deposit(
-      cryptofolioAddress,
-      tradeFloorTokenId,
+  it('should increase possible token IDs', async function () {
+    this.timeout(60 * 1000);
+
+    const { tradeFloorClientLP } = contracts;
+
+    // Test parameters
+    const defaultTokenIdCount = 8;
+    const testTokenIdCount = 16;
+
+    // Check number of token IDs
+    let numTokenIds = await tradeFloorClientLP.numTradeFloorTokenIds();
+    chai.expect(numTokenIds).to.equal(defaultTokenIdCount);
+
+    // Fail to decrease possible token IDs
+    let tx = tradeFloorClientLP.setNumTokenIds(0);
+    await chai.expect(tx).to.be.revertedWith('TFCLP: increase only');
+
+    // Increase possible token IDs
+    tx = tradeFloorClientLP.setNumTokenIds(testTokenIdCount);
+    await chai
+      .expect(tx)
+      .to.emit(tradeFloorClientLP, 'TokenIdCountChanged')
+      .withArgs(testTokenIdCount);
+
+    // Check number of token IDs
+    numTokenIds = await tradeFloorClientLP.numTradeFloorTokenIds();
+    chai.expect(numTokenIds).to.equal(testTokenIdCount);
+  });
+
+  it('should revert when depositing LP NFT into boi cryptofolio', async function () {
+    this.timeout(60 * 1000);
+
+    const { tradeFloorProxyContract, tradeFloorClientLP } = contracts;
+
+    // Deposit LP tokens to boi should fail
+    const tx = tradeFloorClientLP.deposit(
+      cryptofolioAddressBoi,
+      tradeFloorTokenIdBoi,
+      lpBalance
+    );
+    await chai.expect(tx).to.be.revertedWith('TFCLP: Wolves only');
+
+    // Boi cryptofolio should be in its original state
+    const [tokenIds, idsLength] = await cryptofolioContractBoi.getCryptofolio(
+      tradeFloorProxyContract.address
+    );
+    chai.expect(idsLength).to.equal(0);
+  });
+
+  it('should deposit LP NFT into wolf cryptofolio', async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      uniV2PairContract,
+      tradeFloorProxyContract,
+      tradeFloorClientLP,
+    } = contracts;
+
+    // Deposit LP tokens to wolf
+    const tx = tradeFloorClientLP.deposit(
+      cryptofolioAddressWolf,
+      tradeFloorTokenIdWolf,
       lpBalance
     );
     await chai
@@ -348,34 +478,50 @@ describe('TradeFloorClientLP', function () {
       .withArgs(marketingWallet.address, tradeFloorClientLP.address, lpBalance);
     await chai
       .expect(tx)
-      .to.emit(cryptofolioContract, 'CryptoFolioAdded')
+      .to.emit(cryptofolioContractWolf, 'CryptoFolioAdded')
       .withArgs(
-        cryptofolioAddress,
+        cryptofolioAddressWolf,
         tradeFloorProxyContract.address,
-        [tradeFloorTokenId],
+        [tradeFloorTokenIdWolf],
         [lpBalance]
       );
     await chai
       .expect(tx)
       .to.emit(tradeFloorClientLP, 'Deposit')
-      .withArgs(marketingWallet.address, cryptofolioAddress, lpBalance, 0);
+      .withArgs(marketingWallet.address, cryptofolioAddressWolf, lpBalance, 0);
 
     // Check cryptofolio and the LP NFT should appear
-    let [tokenIds, idsLength] = await cryptofolioContract.getCryptofolio(
+    const [tokenIds, idsLength] = await cryptofolioContractWolf.getCryptofolio(
       tradeFloorProxyContract.address
     );
     chai.expect(idsLength).to.equal(1);
-    chai.expect(tokenIds[0]).to.equal(tradeFloorTokenId);
+    chai.expect(tokenIds[0]).to.equal(tradeFloorTokenIdWolf);
+  });
+
+  it('should attach the trade floor proxy', async function () {
+    this.timeout(60 * 1000);
+
+    const { tradeFloorContract, tradeFloorProxyContract } = contracts;
 
     // Attach the proxy and set marketing wallet signer
-    const tradeFloorProxyInstance = tradeFloorContract
+    tradeFloorProxyInstance = tradeFloorContract
       .attach(tradeFloorProxyContract.address)
       .connect(marketingWallet);
+  });
+
+  it('should burn half the LP NFT', async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      uniV2PairContract,
+      tradeFloorProxyContract,
+      tradeFloorClientLP,
+    } = contracts;
 
     // Burn half the NFT
-    tx = tradeFloorProxyInstance.burn(
-      cryptofolioAddress,
-      tradeFloorTokenId,
+    const tx = tradeFloorProxyInstance.burn(
+      cryptofolioAddressWolf,
+      tradeFloorTokenIdWolf,
       lpBalance.div(2)
     );
     await chai
@@ -388,22 +534,32 @@ describe('TradeFloorClientLP', function () {
       );
 
     // Check wallet balance
-    let newLpBalance = await uniV2PairContract.balanceOf(
+    const newLpBalance = await uniV2PairContract.balanceOf(
       marketingWallet.address
     );
     chai.expect(newLpBalance).to.equal(lpBalance.div(2));
 
     // Check the cryptofolio again and verify it holds the NFT
-    [tokenIds, idsLength] = await cryptofolioContract.getCryptofolio(
+    const [tokenIds, idsLength] = await cryptofolioContractWolf.getCryptofolio(
       tradeFloorProxyContract.address
     );
     chai.expect(idsLength).to.equal(1);
-    chai.expect(tokenIds[0]).to.equal(tradeFloorTokenId);
+    chai.expect(tokenIds[0]).to.equal(tradeFloorTokenIdWolf);
+  });
+
+  it('should burn almost the other half of the LP NFT', async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      uniV2PairContract,
+      tradeFloorProxyContract,
+      tradeFloorClientLP,
+    } = contracts;
 
     // Burn *almost* the other half of the NFT
-    tx = tradeFloorProxyInstance.burn(
-      cryptofolioAddress,
-      tradeFloorTokenId,
+    const tx = tradeFloorProxyInstance.burn(
+      cryptofolioAddressWolf,
+      tradeFloorTokenIdWolf,
       lpBalance.div(2).sub(1)
     );
     await chai
@@ -416,35 +572,60 @@ describe('TradeFloorClientLP', function () {
       );
 
     // Check wallet balance
-    newLpBalance = await uniV2PairContract.balanceOf(marketingWallet.address);
+    const newLpBalance = await uniV2PairContract.balanceOf(
+      marketingWallet.address
+    );
     chai.expect(newLpBalance).to.equal(lpBalance.sub(1));
 
     // Check the cryptofolio again and verify it holds the NFT
-    [tokenIds, idsLength] = await cryptofolioContract.getCryptofolio(
+    const [tokenIds, idsLength] = await cryptofolioContractWolf.getCryptofolio(
       tradeFloorProxyContract.address
     );
     chai.expect(idsLength).to.equal(1);
-    chai.expect(tokenIds[0]).to.equal(tradeFloorTokenId);
+    chai.expect(tokenIds[0]).to.equal(tradeFloorTokenIdWolf);
+  });
+
+  it('should burn the dust', async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      uniV2PairContract,
+      tradeFloorProxyContract,
+      tradeFloorClientLP,
+    } = contracts;
 
     // Burn the dust
-    tx = tradeFloorProxyInstance.burn(cryptofolioAddress, tradeFloorTokenId, 1);
+    const tx = tradeFloorProxyInstance.burn(
+      cryptofolioAddressWolf,
+      tradeFloorTokenIdWolf,
+      1
+    );
     await chai
       .expect(tx)
       .to.emit(uniV2PairContract, 'Transfer')
       .withArgs(tradeFloorClientLP.address, marketingWallet.address, 1);
 
     // Check the cryptofolio again and it should be in its original state
-    [tokenIds, idsLength] = await cryptofolioContract.getCryptofolio(
+    const [tokenIds, idsLength] = await cryptofolioContractWolf.getCryptofolio(
       tradeFloorProxyContract.address
     );
     chai.expect(idsLength).to.equal(0);
+  });
 
-    //
-    // Test re-staking the LP NFT for thoroughness
-    //
+  it('should test re-staking LP NFT', async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      uniV2PairContract,
+      tradeFloorProxyContract,
+      tradeFloorClientLP,
+    } = contracts;
 
     // Approve LP tokens again for another deposit
-    tx = await uniV2PairContract.approve(tradeFloorClientLP.address, lpBalance);
+    let tx = await uniV2PairContract.approve(
+      tradeFloorClientLP.address,
+      lpBalance
+    );
     await chai.expect(tx).to.emit(uniV2PairContract, 'Approval').withArgs(
       marketingWallet.address, // owner
       tradeFloorClientLP.address, // spender
@@ -453,8 +634,8 @@ describe('TradeFloorClientLP', function () {
 
     // Deposit LP tokens again
     tx = tradeFloorClientLP.deposit(
-      cryptofolioAddress,
-      tradeFloorTokenId,
+      cryptofolioAddressWolf,
+      tradeFloorTokenIdWolf,
       lpBalance
     );
     await chai
@@ -463,29 +644,29 @@ describe('TradeFloorClientLP', function () {
       .withArgs(marketingWallet.address, tradeFloorClientLP.address, lpBalance);
     await chai
       .expect(tx)
-      .to.emit(cryptofolioContract, 'CryptoFolioAdded')
+      .to.emit(cryptofolioContractWolf, 'CryptoFolioAdded')
       .withArgs(
-        cryptofolioAddress,
+        cryptofolioAddressWolf,
         tradeFloorProxyContract.address,
-        [tradeFloorTokenId],
+        [tradeFloorTokenIdWolf],
         [lpBalance]
       );
     await chai
       .expect(tx)
       .to.emit(tradeFloorClientLP, 'Deposit')
-      .withArgs(marketingWallet.address, cryptofolioAddress, lpBalance, 0);
+      .withArgs(marketingWallet.address, cryptofolioAddressWolf, lpBalance, 0);
 
     // Check the cryptofolio again and the LP NFT should appear
-    [tokenIds, idsLength] = await cryptofolioContract.getCryptofolio(
+    let [tokenIds, idsLength] = await cryptofolioContractWolf.getCryptofolio(
       tradeFloorProxyContract.address
     );
     chai.expect(idsLength).to.equal(1);
-    chai.expect(tokenIds[0]).to.equal(tradeFloorTokenId);
+    chai.expect(tokenIds[0]).to.equal(tradeFloorTokenIdWolf);
 
     // Burn the NFT
     tx = tradeFloorProxyInstance.burn(
-      cryptofolioAddress,
-      tradeFloorTokenId,
+      cryptofolioAddressWolf,
+      tradeFloorTokenIdWolf,
       lpBalance
     );
     await chai
@@ -494,7 +675,7 @@ describe('TradeFloorClientLP', function () {
       .withArgs(tradeFloorClientLP.address, marketingWallet.address, lpBalance);
 
     // Check the cryptofolio again and it should be in its original state
-    [tokenIds, idsLength] = await cryptofolioContract.getCryptofolio(
+    [tokenIds, idsLength] = await cryptofolioContractWolf.getCryptofolio(
       tradeFloorProxyContract.address
     );
     chai.expect(idsLength).to.equal(0);


### PR DESCRIPTION
## Description

This PR contains two commits:

* Expands TFCLP test cases
* Adds gas costs for mutating contract calls

## How has this been tested?

Output of `yarn test-chain`:

```
  TradeFloorClientLP
ETH price is $2311.97
Using 'AVERAGE' gas at 120 Gwei
    ✓ should approve spending WOWS
Mint boi gas used: 377897 (0.045 ETH / $104.04)
    ✓ should mint boi SFT (73ms)
Mint wolf gas used: 329397 (0.039 ETH / $90.17)
    ✓ should mint wolf SFT (76ms)
    ✓ should check token ownership
    ✓ should check token IDs
    ✓ should query boi token ID
    ✓ should query wolf token ID
    ✓ should get addresses of clone contracts
    ✓ should know the token IDs of clone contracts
    ✓ should get LP tokens (1173ms)
    ✓ should check wallet balance
    ✓ should instantiate cryptofolio contracts
Approve LP gas used: 46074 (0.005 ETH / $11.56)
    ✓ should approve TFCLP to transfer tokens
    ✓ should increase possible token IDs
    ✓ should revert when depositing LP NFT into boi cryptofolio
Deposit LP gas used: 247347 (0.029 ETH / $67.05)
    ✓ should deposit LP NFT into wolf cryptofolio (274ms)
    ✓ should attach the trade floor proxy
Burn LP NFT gas used: 85459 (0.01 ETH / $23.12)
    ✓ should burn half the LP NFT (128ms)
    ✓ should burn almost the other half of the LP NFT (127ms)
    ✓ should burn the dust (106ms)
    ✓ should test re-staking LP NFT (345ms)
```