### PR TITLE
Prettier tests for audit

### DIFF
--- a/test/web3/test-presale.ts
+++ b/test/web3/test-presale.ts
@@ -156,8 +156,8 @@ describe('Presale contract', function () {
     const ethUsd = await toUsd(1);
     const gasPrice = await getGasPrice();
 
-    console.log(`ETH price is $${ethUsd}`);
-    console.log(`Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
+    console.log(`    ETH price is $${ethUsd}`);
+    console.log(`    Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
   });
 
   beforeEach(async function () {
@@ -318,7 +318,7 @@ describe('Presale contract', function () {
       (initialBalance - finalBalance - amount).toFixed(4)
     );
     console.log(
-      `Buy token gas cost: ${gasCost} ETH ($${await toUsd(gasCost)})`
+      `    Buy token gas cost: ${gasCost} ETH ($${await toUsd(gasCost)})`
     );
 
     // Check token balance
@@ -425,7 +425,7 @@ describe('Presale contract', function () {
       (initialBalance - finalBalance - amount).toFixed(4)
     );
     console.log(
-      `Buy liquidity gas cost: ${gasCost} ETH ($${await toUsd(gasCost)})`
+      `    Buy liquidity gas cost: ${gasCost} ETH ($${await toUsd(gasCost)})`
     );
 
     // Check marketing ETH balance
@@ -496,7 +496,7 @@ describe('Presale contract', function () {
     );
     const gasCost = parseFloat((currentBalance - finalBalance).toFixed(4));
     console.log(
-      `Transfer stake gas cost: ${gasCost} ETH ($${await toUsd(gasCost)})`
+      `    Transfer stake gas cost: ${gasCost} ETH ($${await toUsd(gasCost)})`
     );
   });
 });

--- a/test/web3/test-reward-farms.ts
+++ b/test/web3/test-reward-farms.ts
@@ -233,8 +233,8 @@ describe('Reward farms', function () {
     const ethUsd = await toUsd(1);
     const gasPrice = await getGasPrice();
 
-    console.log(`ETH price is $${ethUsd}`);
-    console.log(`Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
+    console.log(`    ETH price is $${ethUsd}`);
+    console.log(`    Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
   });
 
   it('should attach the trade floor proxy', async function () {
@@ -507,7 +507,7 @@ describe('Reward farms', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Deposit LP NFT gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Deposit LP NFT gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );
@@ -573,7 +573,7 @@ describe('Reward farms', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Transfer cryptofolio item NFT gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Transfer c-folio item NFT gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );
@@ -612,7 +612,7 @@ describe('Reward farms', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Burn cryptofolio item NFT gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Burn c-folio item NFT gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );

--- a/test/web3/test-sft-minter.ts
+++ b/test/web3/test-sft-minter.ts
@@ -225,8 +225,8 @@ describe('SFT minter', function () {
     const ethUsd = await toUsd(1);
     const gasPrice = await getGasPrice();
 
-    console.log(`ETH price is $${ethUsd}`);
-    console.log(`Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
+    console.log(`    ETH price is $${ethUsd}`);
+    console.log(`    Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
   });
 
   it('should attach the trade floor proxy', async function () {
@@ -373,7 +373,7 @@ describe('SFT minter', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Mint boi gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Mint boi SFT gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );
@@ -405,7 +405,7 @@ describe('SFT minter', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Mint wolf gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Mint wolf SFT gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );
@@ -568,7 +568,7 @@ describe('SFT minter', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Mint investment SFT gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Mint investment SFT gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );

--- a/test/web3/test-trade-floor.ts
+++ b/test/web3/test-trade-floor.ts
@@ -196,8 +196,8 @@ describe('Trade Floor', function () {
     const ethUsd = await toUsd(1);
     const gasPrice = await getGasPrice();
 
-    console.log(`ETH price is $${ethUsd}`);
-    console.log(`Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
+    console.log(`    ETH price is $${ethUsd}`);
+    console.log(`    Using '${GAS_PRICE}' gas at ${gasPrice / 1e9} Gwei`);
   });
 
   it('should attach the trade floor proxy', async function () {
@@ -348,7 +348,7 @@ describe('Trade Floor', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Lock cryptofolio gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Lock cryptofolio gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );
@@ -395,7 +395,7 @@ describe('Trade Floor', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Transfer locked cryptofolio NFT gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Transfer locked cryptofolio NFT gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );
@@ -436,7 +436,7 @@ describe('Trade Floor', function () {
         .mul(await getGasPrice())
         .div(ethers.BigNumber.from('1000000000000000')) / 1000.0;
     console.log(
-      `Burn locked cryptofolio NFT gas used: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
+      `    Burn locked cryptofolio NFT gas: ${gasUsedGwei} (${gasCost} ETH / $${await toUsd(
         gasCost
       )})`
     );


### PR DESCRIPTION
What better way than to communicate our extensive testing than to plop a screenshot in the audit report? `</s>` Let's make tests prettier for the screenshot.

Before:

![Screenshot from 2021-05-07 17-45-47](https://user-images.githubusercontent.com/15795328/117520246-1f2fa400-af5c-11eb-804e-f33563e1ab72.png)

After:

![Screenshot from 2021-05-07 17-46-28](https://user-images.githubusercontent.com/15795328/117520264-2e165680-af5c-11eb-98af-406c2d5dca8b.png)
