### PR TITLE
Add Slither static analysis

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,8 +32,10 @@ jobs:
         include:
           - os: ubuntu-18.04
             node-version: 14
+            python-version: 3.6
           - os: ubuntu-20.04
             node-version: 16
+            python-version: 3.9
 
     # Steps represent a sequence of tasks that will be executed as part of the
     # job
@@ -119,11 +121,19 @@ jobs:
         if: steps.restore-contracts.outputs.cache-hit != 'true'
         run: yarn depends
 
-      - name: yarn lint
-        run: yarn lint
-
       - name: yarn compile
         run: yarn compile
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: pip3 install -r requirements.txt
+
+      - name: yarn lint
+        run: yarn lint
 
       - name: yarn hardhat:deploy
         run: yarn hardhat:deploy

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -100,6 +100,14 @@ jobs:
             tools/repos/curve-contracts
           key: restore-curve-${{ hashFiles('tools/depends/chain/curve-contracts/**') }}
 
+      - name: Restore downloaded dependencies
+        id: restore-downloads
+        uses: actions/cache@v2
+        with:
+          path: |
+            tools/bin
+          key: restore-downloads-${{ hashFiles('tools/download-depends.sh') }}
+
       - name: yarn install
         if: steps.restore-node.outputs.cache-hit != 'true'
         run: yarn install

--- a/contracts/src/crowdsale/Crowdsale.sol
+++ b/contracts/src/crowdsale/Crowdsale.sol
@@ -431,7 +431,9 @@ contract Crowdsale is Context, ReentrancyGuard, ERC20Recovery {
 
     // Transfer all tokens from this contract to _wallet
     uint256 tokenInContract = token.balanceOf(address(this));
-    if (tokenInContract > 0) token.transfer(_wallet, tokenInContract);
+    if (tokenInContract > 0) {
+      require(token.transfer(_wallet, tokenInContract), 'CS: Xfer failed');
+    }
 
     // Finally whitelist uniV2 LP pool on token contract
     token.enableUniV2Pair(true);
@@ -505,7 +507,7 @@ contract Crowdsale is Context, ReentrancyGuard, ERC20Recovery {
     internal
   {
     require(token.mint(address(this), _tokenAmount), 'minting failed');
-    token.transfer(_beneficiary, _tokenAmount);
+    require(token.transfer(_beneficiary, _tokenAmount), 'CS: Xfer failed');
   }
 
   /**
@@ -585,7 +587,10 @@ contract Crowdsale is Context, ReentrancyGuard, ERC20Recovery {
 
     // Send remaining WOWS token to team wallet
     if (amountToken < tokenBalance)
-      token.transfer(remainingReceiver, tokenBalance.sub(amountToken));
+      require(
+        token.transfer(remainingReceiver, tokenBalance.sub(amountToken)),
+        'CS: Xfer failed'
+      );
 
     return liquidity;
   }

--- a/contracts/src/crowdsale/WOWSSftMinter.sol
+++ b/contracts/src/crowdsale/WOWSSftMinter.sol
@@ -218,6 +218,12 @@ contract WOWSSftMinter is Context, Ownable {
    */
   function destructContract() external onlyOwner {
     emit Destruct();
+
+    // Disable high-impact Slither detector "suicidal" here. Slither explains
+    // that "WOWSSftMinter.destructContract() allows anyone to destruct the
+    // contract", which is not the case due to the {Ownable-onlyOwner} modifier.
+    //
+    // slither-disable-next-line suicidal
     selfdestruct(msg.sender);
   }
 

--- a/contracts/src/investment/RewardHandler.sol
+++ b/contracts/src/investment/RewardHandler.sol
@@ -134,7 +134,10 @@ contract RewardHandler is Context, AccessControl, IRewardHandler {
     // Transfer WOWS to the new rewardHandler
     uint256 amountRewards = rewardToken.balanceOf(address(this));
     if (amountRewards > 0)
-      rewardToken.transfer(newRewardHandler, amountRewards);
+      require(
+        rewardToken.transfer(newRewardHandler, amountRewards),
+        'RH: Xfer failed'
+      );
 
     // Destroy contract
     if (destroy) selfdestruct(payable(newRewardHandler));
@@ -263,7 +266,10 @@ contract RewardHandler is Context, AccessControl, IRewardHandler {
       }
 
       // Now send rewards to the user
-      rewardToken.transfer(recipient, recipientAmount);
+      require(
+        rewardToken.transfer(recipient, recipientAmount),
+        'RH: Xfer failed'
+      );
     }
   }
 
@@ -319,17 +325,26 @@ contract RewardHandler is Context, AccessControl, IRewardHandler {
         rewardToken.mint(address(this), distributeAmount.sub(balance));
 
       // Distribute the fee
-      rewardToken.transfer(
-        teamWallet,
-        distributeAmount.mul(FEE_TO_TEAM).div(1e6)
+      require(
+        rewardToken.transfer(
+          teamWallet,
+          distributeAmount.mul(FEE_TO_TEAM).div(1e6)
+        ),
+        'RH: Xfer failed'
       );
-      rewardToken.transfer(
-        marketingWallet,
-        distributeAmount.mul(FEE_TO_MARKETING).div(1e6)
+      require(
+        rewardToken.transfer(
+          marketingWallet,
+          distributeAmount.mul(FEE_TO_MARKETING).div(1e6)
+        ),
+        'RH: Xfer failed'
       );
-      rewardToken.transfer(
-        booster,
-        distributeAmount.mul(FEE_TO_BOOSTER).div(1e6)
+      require(
+        rewardToken.transfer(
+          booster,
+          distributeAmount.mul(FEE_TO_BOOSTER).div(1e6)
+        ),
+        'RH: Xfer failed'
       );
     }
     return rewardToken;

--- a/contracts/src/investment/RewardHandler.sol
+++ b/contracts/src/investment/RewardHandler.sol
@@ -140,7 +140,15 @@ contract RewardHandler is Context, AccessControl, IRewardHandler {
       );
 
     // Destroy contract
-    if (destroy) selfdestruct(payable(newRewardHandler));
+    if (destroy) {
+      // Disable high-impact Slither detector "suicidal" here. Slither explains
+      // that "RewardHandler.terminate() allows anyone to destruct the
+      // contract", which is not the case due to validatation of the sender
+      // having the {AccessControl-DEFAULT_ADMIN_ROLE} role.
+      //
+      // slither-disable-next-line suicidal
+      selfdestruct(payable(newRewardHandler));
+    }
   }
 
   /**

--- a/contracts/src/investment/RewardHandler.sol
+++ b/contracts/src/investment/RewardHandler.sol
@@ -174,6 +174,12 @@ contract RewardHandler is Context, AccessControl, IRewardHandler {
       ethRoute[0] = router.WETH();
       ethRoute[1] = rewardToken;
 
+      // Disable high-impact Slither detector "arbitrary-send" here. Slither
+      // recommends that programmers "Ensure that an arbitrary user cannot
+      // withdraw unauthorized funds." We accomplish this by using access
+      // control to prevent unauthorized modification of the destination.
+      //
+      // slither-disable-next-line arbitrary-send
       uint256[] memory amounts =
         router.swapExactETHForTokens{ value: amountETH }(
           0,

--- a/contracts/test/strategies/StrategyHODL.sol
+++ b/contracts/test/strategies/StrategyHODL.sol
@@ -98,7 +98,7 @@ contract StrategyHODL is IStrategy, Context {
     address vault = _controller.vaults(address(this));
     require(vault != address(0), '!vault'); // Additional protection so we don't burn the funds
 
-    _want.transfer(vault, amount);
+    require(_want.transfer(vault, amount), 'HODL: Xfer failed');
   }
 
   function skim() external override {}
@@ -115,7 +115,7 @@ contract StrategyHODL is IStrategy, Context {
 
     uint256 balance = _want.balanceOf(address(this));
 
-    _want.transfer(vault, balance);
+    require(_want.transfer(vault, balance), 'HODL: Xfer failed');
 
     return balance;
   }

--- a/contracts/utils/TestnetFaucet.sol
+++ b/contracts/utils/TestnetFaucet.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 // rinkeby: 0x139C0D4ce21Bb5d1376fc56a1f01057259f28205
 
+pragma solidity >=0.7.0 <0.8.0;
+
 interface Stable {
   function mint(address account, uint256 amount) external;
 }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "scripts": {
     "audit": "audit-ci --moderate --package-manager yarn --allowlist postcss lodash underscore --report-type summary",
     "build": "react-scripts build",
-    "clean": "rimraf artifacts build cache contracts/bytecode contracts/depends depends deployments node_modules src/abi",
+    "clean": "rimraf artifacts build cache contracts/bytecode contracts/depends depends deployments node_modules src/abi tools/bin tools/repos",
     "compile": "hardhat compile",
     "create-metadata": "cd metadata && node create_metadata.ts",
-    "depends": "bash tools/build-depends.sh",
+    "depends": "bash tools/download-depends.sh && bash tools/build-depends.sh",
     "deploy": "gh-pages -b master -r https://github.com/wolvesofwallstreet/wolvesofwallstreet.github.io.git -d build",
     "format": "prettier --write . && eslint --fix .",
     "goerli:deploy": "hardhat --network goerli deploy",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "kovan:verify": "hardhat --network kovan etherscan-verify --solc-input",
     "lint": "yarn lint-chain && yarn lint-app",
     "lint-app": "prettier --check . && eslint .",
-    "lint-chain": "solhint 'contracts/interfaces/**/*.sol' 'contracts/src/**/*.sol' 'contracts/test/**/*.sol' --max-warnings 0",
+    "lint-chain": "solhint 'contracts/interfaces/**/*.sol' 'contracts/src/**/*.sol' 'contracts/test/**/*.sol' --max-warnings 0 && slither .",
     "local-node": "hardhat node --network hardhat",
     "local:deploy": "hardhat --network localhost deploy",
     "local:export": "hardhat --network localhost export",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# A patched Slither is needed due to incorrect detections when analyzing our
+# code. Some bugs are being reported upstream.
+git+git://github.com/wolvesofwallstreet/crytic-compile.git@wows-fixes#egg=crytic_compile
+git+git://github.com/wolvesofwallstreet/slither.git@wows-fixes#egg=slither_analyzer

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,12 @@
+{
+  "detectors_to_exclude": "name-reused",
+  "exclude_high": false,
+  "exclude_medium": true,
+  "exclude_low": true,
+  "exclude_informational": true,
+  "exclude_optimization": true,
+  "exclude_dependencies": false,
+  "filter_paths": "@openzeppelin,bytecode,depends",
+  "solc": "tools/bin/solc-0.7.4",
+  "solc_disable_warnings": true
+}

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,6 @@
+# Dependency binaries
+bin/
+
 # Dependency build files
 build/
 

--- a/tools/download-depends.sh
+++ b/tools/download-depends.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+################################################################################
+#
+#  Copyright (C) 2021 The Wolfpack
+#  This file is part of wolves.finance - https://github.com/wolvesofwallstreet/wolves.finance
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See the file LICENSE.txt for more information.
+#
+################################################################################
+
+#
+# Script to download static dependencies
+#
+# Requirements:
+#
+#   - curl
+#
+
+# Enable strict mode
+set -o errexit
+set -o pipefail
+set -o nounset
+
+#
+# Environment configuration
+#
+
+# When this changes, update the version in slither.config.json
+SOLC_VERSION="0.7.4"
+
+SOLC_URL="https://github.com/ethereum/solidity/releases/download/v${SOLC_VERSION}/solc-static-linux"
+
+#
+# Environment paths
+#
+
+# Get the absolute path to this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Directory of the dependency build definitions
+BIN_DIR="${SCRIPT_DIR}/bin"
+
+# Name of solc binary
+SOLC_BIN="solc-${SOLC_VERSION}"
+
+# Final path of solc binary
+SOLC_PATH="${BIN_DIR}/${SOLC_BIN}"
+
+# Ensure directories exist
+mkdir -p "${BIN_DIR}"
+
+#
+# Download dependencies
+#
+
+if [ -f "${SOLC_PATH}" ]; then
+  echo "Using existing ${SOLC_BIN}"
+else
+  curl --location --output "${SOLC_PATH}" "${SOLC_URL}"
+fi
+
+#
+# Set permissions
+#
+
+chmod +x "${SOLC_PATH}"


### PR DESCRIPTION
## Description

This PR adds support for static analysis via Slither. It also corrects or disables all 13 high-impact detections.

Patched versions of [slither](https://github.com/wolvesofwallstreet/slither) and [crytic-compile](https://github.com/wolvesofwallstreet/crytic-compile) are needed. Without these patches, Slither fails to parse our code, raising exceptions in the compiler and analyzer. 

Beyond the parsing fixes, Slither failed to detect issues correctly. It reported 22 detections instead of 13. I applied two patches, and Slither then reported the correct number of high-impact detections. For one patch, I was able to trace down the root cause and fix the issue. I plan to upstream this fix.

## How has this been tested?

See CI results for a Slither run with all changes in the PR applied. To test the null hypothesis, without the [SOL] changes in this PR, Slither analysis returns an error and it correctly reports the 13 high-impact detections.