### PR TITLE
Add SafeERC20 implementation to 0x contracts based on OZ

### DIFF
--- a/contracts/0xerc1155/utils/Address.sol
+++ b/contracts/0xerc1155/utils/Address.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT AND Apache-2.0
 pragma solidity 0.7.4;
 
 /**
@@ -24,5 +24,47 @@ library Address {
       codehash := extcodehash(_address)
     }
     return (codehash != 0x0 && codehash != ACCOUNT_HASH);
+  }
+
+  /**
+   * @dev Performs a Solidity function call using a low level `call`.
+   *
+   * If `target` reverts with a revert reason, it is bubbled up by this
+   * function (like regular Solidity function calls).
+   *
+   * Returns the raw returned data. To convert to the expected return value,
+   * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+   *
+   * Requirements:
+   *
+   * - `target` must be a contract.
+   * - calling `target` with `data` must not revert.
+   */
+  function functionCall(
+    address target,
+    bytes memory data,
+    string memory errorMessage
+  ) internal returns (bytes memory) {
+    require(isContract(target), 'Address: call to non-contract');
+
+    // solhint-disable-next-line avoid-low-level-calls
+    (bool success, bytes memory returndata) = target.call(data);
+
+    if (success) {
+      return returndata;
+    } else {
+      // Look for revert reason and bubble it up if present
+      if (returndata.length > 0) {
+        // The easiest way to bubble the revert reason is using memory via assembly
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+          let returndata_size := mload(returndata)
+          revert(add(32, returndata), returndata_size)
+        }
+      } else {
+        revert(errorMessage);
+      }
+    }
   }
 }

--- a/contracts/0xerc1155/utils/SafeERC20.sol
+++ b/contracts/0xerc1155/utils/SafeERC20.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT AND Apache-2.0
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import '../interfaces/IERC20.sol';
+import '../utils/SafeMath.sol';
+import '../utils/Address.sol';
+
+/**
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20 {
+  using SafeMath for uint256;
+  using Address for address;
+
+  function safeTransfer(
+    IERC20 token,
+    address to,
+    uint256 value
+  ) internal {
+    _callOptionalReturn(
+      token,
+      abi.encodeWithSelector(token.transfer.selector, to, value)
+    );
+  }
+
+  function safeTransferFrom(
+    IERC20 token,
+    address from,
+    address to,
+    uint256 value
+  ) internal {
+    _callOptionalReturn(
+      token,
+      abi.encodeWithSelector(token.transferFrom.selector, from, to, value)
+    );
+  }
+
+  /**
+   * @dev Deprecated. This function has issues similar to the ones found in
+   * {IERC20-approve}, and its usage is discouraged.
+   *
+   * Whenever possible, use {safeIncreaseAllowance} and
+   * {safeDecreaseAllowance} instead.
+   */
+  function safeApprove(
+    IERC20 token,
+    address spender,
+    uint256 value
+  ) internal {
+    // safeApprove should only be called when setting an initial allowance,
+    // or when resetting it to zero. To increase and decrease it, use
+    // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+    // solhint-disable-next-line max-line-length
+    require(
+      (value == 0) || (token.allowance(address(this), spender) == 0),
+      'SafeERC20: approve from non-zero to non-zero allowance'
+    );
+    _callOptionalReturn(
+      token,
+      abi.encodeWithSelector(token.approve.selector, spender, value)
+    );
+  }
+
+  function safeIncreaseAllowance(
+    IERC20 token,
+    address spender,
+    uint256 value
+  ) internal {
+    uint256 newAllowance = token.allowance(address(this), spender).add(value);
+    _callOptionalReturn(
+      token,
+      abi.encodeWithSelector(token.approve.selector, spender, newAllowance)
+    );
+  }
+
+  function safeDecreaseAllowance(
+    IERC20 token,
+    address spender,
+    uint256 value
+  ) internal {
+    uint256 newAllowance = token.allowance(address(this), spender).sub(value);
+    _callOptionalReturn(
+      token,
+      abi.encodeWithSelector(token.approve.selector, spender, newAllowance)
+    );
+  }
+
+  /**
+   * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+   * on the return value: the return value is optional (but if data is returned, it must not be false).
+   * @param token The token targeted by the call.
+   * @param data The call data (encoded using abi.encode or one of its variants).
+   */
+  function _callOptionalReturn(IERC20 token, bytes memory data) private {
+    // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+    // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
+    // the target address contains contract code and also asserts for success in the low-level call.
+
+    bytes memory returndata =
+      address(token).functionCall(data, 'SafeERC20: low-level call failed');
+    if (returndata.length > 0) {
+      // Return data is optional
+      // solhint-disable-next-line max-line-length
+      require(
+        abi.decode(returndata, (bool)),
+        'SafeERC20: ERC20 operation did not succeed'
+      );
+    }
+  }
+}

--- a/contracts/src/cfolio/CFolioItemHandlerSC.sol
+++ b/contracts/src/cfolio/CFolioItemHandlerSC.sol
@@ -13,6 +13,7 @@ import '@openzeppelin/contracts/utils/Context.sol';
 import '../../0xerc1155/interfaces/IERC1155.sol';
 import '../../0xerc1155/interfaces/IERC1155TokenReceiver.sol';
 import '../../0xerc1155/interfaces/IERC20.sol';
+import '../../0xerc1155/utils/SafeERC20.sol';
 import '../../0xerc1155/utils/SafeMath.sol';
 import '../../interfaces/curve/CurveDepositInterface.sol';
 
@@ -43,6 +44,7 @@ import './interfaces/ISFTEvaluator.sol';
 contract CFolioItemHandlerSC is ICFolioItemHandler, Context {
   using SafeMath for uint256;
   using TokenIds for uint256;
+  using SafeERC20 for IERC20;
 
   //////////////////////////////////////////////////////////////////////////////
   // Routing
@@ -172,7 +174,7 @@ contract CFolioItemHandlerSC is ICFolioItemHandler, Context {
     // Approve stablecoin spending
     for (uint256 i = 0; i < 4; ++i) {
       address underlyingCoin = curveYDeposit.underlying_coins(int128(i));
-      IERC20(underlyingCoin).approve(address(curveYDeposit), uint256(-1));
+      IERC20(underlyingCoin).safeApprove(address(curveYDeposit), uint256(-1));
     }
 
     // Approve yCRV spending
@@ -301,7 +303,11 @@ contract CFolioItemHandlerSC is ICFolioItemHandler, Context {
       for (uint256 i = 0; i < 4; ++i) {
         address underlyingCoin = curveYDeposit.underlying_coins(int128(i));
 
-        IERC20(underlyingCoin).transferFrom(payer, address(this), amounts[i]);
+        IERC20(underlyingCoin).safeTransferFrom(
+          payer,
+          address(this),
+          amounts[i]
+        );
 
         uint256 stableAmount = IERC20(underlyingCoin).balanceOf(address(this));
 
@@ -376,7 +382,7 @@ contract CFolioItemHandlerSC is ICFolioItemHandler, Context {
     for (uint256 i = 0; i < 4; ++i) {
       address underlyingCoin = curveYDeposit.underlying_coins(int128(i));
 
-      IERC20(underlyingCoin).transferFrom(
+      IERC20(underlyingCoin).safeTransferFrom(
         _msgSender(),
         address(this),
         amounts[i]
@@ -473,7 +479,7 @@ contract CFolioItemHandlerSC is ICFolioItemHandler, Context {
         IERC20(underlyingCoin).balanceOf(address(this));
 
       // Transfer stablecoins back to the sender
-      IERC20(underlyingCoin).transfer(_msgSender(), underlyingCoinAmount);
+      IERC20(underlyingCoin).safeTransfer(_msgSender(), underlyingCoinAmount);
     } else {
       // No stablecoins were passed, sender is withdrawing Y pool tokens directly
       // Transfer Y pool tokens back to the sender

--- a/contracts/test/access/TestTetherOwnable.sol
+++ b/contracts/test/access/TestTetherOwnable.sol
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 The Wolfpack
+ * This file is part of wolves.finance - https://github.com/wolvesofwallstreet/wolves.finance
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSES/README.md for more information.
+ */
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @title TestTetherOwnable
+ *
+ * @dev Ownership is not needed nor implemented for the test Tether token.
+ * Transfer fees are issued to the owner, so set owner to address(0) to burn
+ * the fees.
+ *
+ * This contract is a replacement for the {Ownable} contract of mainnet
+ * Tether (0xdac17f958d2ee523a2206206994597c13d831ec7).
+ *
+ * See https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7#code
+ *
+ * FOR TESTING ONLY.
+ */
+contract TestTetherOwnable {
+  /**
+   * @dev Fees sent to the owner are burned
+   */
+  address public owner = address(0);
+}

--- a/contracts/test/token/TestTetherIERC20.sol
+++ b/contracts/test/token/TestTetherIERC20.sol
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 The Wolfpack
+ * This file is part of wolves.finance - https://github.com/wolvesofwallstreet/wolves.finance
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSES/README.md for more information.
+ */
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @title TestTetherIERC20 interface
+ *
+ * @dev Because Tether is not fully consistent with OZ's IERC20 interface, a
+ * specialized IERC20 interface is needed. The interface below comes from the
+ * mainnet Tether contract (0xdac17f958d2ee523a2206206994597c13d831ec7).
+ *
+ * Functions from {ERC20Basic} and {ERC20} of the Tether contract are
+ * concatenated and modernized to form the interface here.
+ *
+ * Ref: https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7#code
+ *
+ * FOR TESTING ONLY.
+ */
+abstract contract TestTetherIERC20 {
+  uint256 public _totalSupply;
+
+  function totalSupply() public view virtual returns (uint256);
+
+  function balanceOf(address who) public view virtual returns (uint256);
+
+  function transfer(address to, uint256 value) public virtual;
+
+  function allowance(address owner, address spender)
+    public
+    view
+    virtual
+    returns (uint256);
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 value
+  ) public virtual;
+
+  function approve(address spender, uint256 value) public virtual;
+
+  event Transfer(address indexed from, address indexed to, uint256 value);
+
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/contracts/test/token/TestTetherMintable.sol
+++ b/contracts/test/token/TestTetherMintable.sol
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 The Wolfpack
+ * This file is part of wolves.finance - https://github.com/wolvesofwallstreet/wolves.finance
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSES/README.md for more information.
+ */
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import './TestTetherToken.sol';
+
+/**
+ * @dev Extension of {TestTetherToken} that allows anyone to mint tokens to
+ * arbitrary accounts.
+ *
+ * FOR TESTING ONLY.
+ */
+contract TestTetherMintable is TestTetherToken {
+  /**
+   *  The contract can be initialized with a number of tokens
+   *  All the tokens are deposited to the owner address
+   *
+   * @param _initialSupply Initial supply of the contract
+   * @param _name Token Name
+   * @param _symbol Token symbol
+   * @param _decimals Token decimals
+   */
+  constructor(
+    uint256 _initialSupply,
+    string memory _name,
+    string memory _symbol,
+    uint256 _decimals
+  ) TestTetherToken(_initialSupply, _name, _symbol, _decimals) {}
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Minting interface
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Creates `amount` tokens and assigns them to `account`, increasing the
+   * total supply.
+   *
+   * Emits a {TestTetherToken-Issue} event.
+   */
+  function mint(address to, uint256 amount) public {
+    // Tokens are issued to the owner
+    owner = to;
+    super.issue(amount);
+    owner = address(0);
+  }
+}

--- a/contracts/test/token/TestTetherToken.sol
+++ b/contracts/test/token/TestTetherToken.sol
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2021 The Wolfpack
+ * This file is part of wolves.finance - https://github.com/wolvesofwallstreet/wolves.finance
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSES/README.md for more information.
+ */
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import '@openzeppelin/contracts/math/SafeMath.sol';
+
+import '../access/TestTetherOwnable.sol';
+
+import './TestTetherIERC20.sol';
+
+/*
+ * Tether is not fully consistent with OZ's IERC20 interface. Therefore, we
+ * can't derive from OZ's {ERC20} contract, and need a basic implementation
+ * that matches mainnet behavior (0xdac17f958d2ee523a2206206994597c13d831ec7).
+ *
+ * This file contains three contracts:
+ *
+ *   - {TestBasicToken} - derived from {BasicToken} of the mainnet contract
+ *   - {TestStandardToken} - derived from {StandardToken} of the mainnet contract
+ *   - {TestTetherToken} - derived from {TetherToken} of the mainnet contract
+ *
+ * To create the contracts below, the code of Tether's three contracts was
+ * imported unmodified. Then, the following transformations were performed:
+ *
+ *   - Mechanical removal of {Ownable} functionality
+ *   - Mechanical removal of {Pausable} functionality
+ *   - Mechanical removal of {Blacklist} functionality
+ *   - Mechanical removal of {UpgradedStandardToken} functionality
+ *   - Mechanical removal of {TetherToken-deprecated} functionality
+ *   - Modernization to compile with Solidity >= 0.7.0
+ *   - Addition of `solhint-disable-next-line reason-string` comments
+ *   - Automated formatting with prettier-plugin-solidity
+ *
+ * Ref: https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7#code
+ *
+ * FOR TESTING ONLY.
+ */
+
+/**
+ * @title Basic token
+ * @dev Basic version of StandardToken, with no allowances.
+ */
+abstract contract TestBasicToken is TestTetherOwnable, TestTetherIERC20 {
+  using SafeMath for uint256;
+
+  mapping(address => uint256) public balances;
+
+  // additional variables for use if transaction fees ever became necessary
+  uint256 public basisPointsRate = 0;
+  uint256 public maximumFee = 0;
+
+  /**
+   * @dev Fix for the ERC20 short address attack.
+   */
+  modifier onlyPayloadSize(uint256 size) {
+    // solhint-disable-next-line reason-string
+    require(!(msg.data.length < size + 4));
+    _;
+  }
+
+  /**
+   * @dev transfer token for a specified address
+   * @param _to The address to transfer to.
+   * @param _value The amount to be transferred.
+   */
+  function transfer(address _to, uint256 _value)
+    public
+    override
+    onlyPayloadSize(2 * 32)
+  {
+    uint256 fee = (_value.mul(basisPointsRate)).div(10000);
+    if (fee > maximumFee) {
+      fee = maximumFee;
+    }
+    uint256 sendAmount = _value.sub(fee);
+    balances[msg.sender] = balances[msg.sender].sub(_value);
+    balances[_to] = balances[_to].add(sendAmount);
+    if (fee > 0) {
+      balances[owner] = balances[owner].add(fee);
+      Transfer(msg.sender, owner, fee);
+    }
+    Transfer(msg.sender, _to, sendAmount);
+  }
+
+  /**
+   * @dev Gets the balance of the specified address.
+   * @param _owner The address to query the the balance of.
+   * @return balance An uint representing the amount owned by the passed address.
+   */
+  function balanceOf(address _owner)
+    public
+    view
+    override
+    returns (uint256 balance)
+  {
+    return balances[_owner];
+  }
+}
+
+/**
+ * @title Standard ERC20 token
+ *
+ * @dev Implementation of the basic standard token.
+ * @dev https://github.com/ethereum/EIPs/issues/20
+ * @dev Based oncode by FirstBlood: https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
+ */
+abstract contract TestStandardToken is TestBasicToken {
+  using SafeMath for uint256;
+
+  mapping(address => mapping(address => uint256)) public allowed;
+
+  uint256 public constant MAX_UINT = 2**256 - 1;
+
+  /**
+   * @dev Transfer tokens from one address to another
+   * @param _from address The address which you want to send tokens from
+   * @param _to address The address which you want to transfer to
+   * @param _value uint the amount of tokens to be transferred
+   */
+  function transferFrom(
+    address _from,
+    address _to,
+    uint256 _value
+  ) public override onlyPayloadSize(3 * 32) {
+    uint256 _allowance = allowed[_from][msg.sender];
+
+    // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
+    // if (_value > _allowance) throw;
+
+    uint256 fee = (_value.mul(basisPointsRate)).div(10000);
+    if (fee > maximumFee) {
+      fee = maximumFee;
+    }
+    if (_allowance < MAX_UINT) {
+      allowed[_from][msg.sender] = _allowance.sub(_value);
+    }
+    uint256 sendAmount = _value.sub(fee);
+    balances[_from] = balances[_from].sub(_value);
+    balances[_to] = balances[_to].add(sendAmount);
+    if (fee > 0) {
+      balances[owner] = balances[owner].add(fee);
+      Transfer(_from, owner, fee);
+    }
+    Transfer(_from, _to, sendAmount);
+  }
+
+  /**
+   * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+   * @param _spender The address which will spend the funds.
+   * @param _value The amount of tokens to be spent.
+   */
+  function approve(address _spender, uint256 _value)
+    public
+    override
+    onlyPayloadSize(2 * 32)
+  {
+    // To change the approve amount you first have to reduce the addresses`
+    //  allowance to zero by calling `approve(_spender, 0)` if it is not
+    //  already 0 to mitigate the race condition described here:
+    //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    // solhint-disable-next-line reason-string
+    require(!((_value != 0) && (allowed[msg.sender][_spender] != 0)));
+
+    allowed[msg.sender][_spender] = _value;
+    Approval(msg.sender, _spender, _value);
+  }
+
+  /**
+   * @dev Function to check the amount of tokens than an owner allowed to a spender.
+   * @param _owner address The address which owns the funds.
+   * @param _spender address The address which will spend the funds.
+   * @return remaining A uint specifying the amount of tokens still available for the spender.
+   */
+  function allowance(address _owner, address _spender)
+    public
+    view
+    override
+    returns (uint256 remaining)
+  {
+    return allowed[_owner][_spender];
+  }
+}
+
+contract TestTetherToken is TestStandardToken {
+  string public name;
+  string public symbol;
+  uint256 public decimals;
+  address public upgradedAddress;
+
+  //  The contract can be initialized with a number of tokens
+  //  All the tokens are deposited to the owner address
+  //
+  // @param _balance Initial supply of the contract
+  // @param _name Token Name
+  // @param _symbol Token symbol
+  // @param _decimals Token decimals
+  constructor(
+    uint256 _initialSupply,
+    string memory _name,
+    string memory _symbol,
+    uint256 _decimals
+  ) {
+    _totalSupply = _initialSupply;
+    name = _name;
+    symbol = _symbol;
+    decimals = _decimals;
+    balances[owner] = _initialSupply;
+  }
+
+  function totalSupply() public view override returns (uint256) {
+    return _totalSupply;
+  }
+
+  // Issue a new amount of tokens
+  // these tokens are deposited into the owner address
+  //
+  // @param _amount Number of tokens to be issued
+  function issue(uint256 amount) public {
+    // solhint-disable-next-line reason-string
+    require(_totalSupply + amount > _totalSupply);
+    // solhint-disable-next-line reason-string
+    require(balances[owner] + amount > balances[owner]);
+
+    balances[owner] += amount;
+    _totalSupply += amount;
+    Issue(amount);
+  }
+
+  // Called when new token are issued
+  event Issue(uint256 amount);
+}

--- a/contracts/test/underlying/TetherToken.sol
+++ b/contracts/test/underlying/TetherToken.sol
@@ -8,13 +8,12 @@
 
 pragma solidity >=0.6.0 <0.8.0;
 
-import '../token/TestERC20Mintable.sol';
+import '../token/TestTetherMintable.sol';
 
 // Mainnet address: 0xdac17f958d2ee523a2206206994597c13d831ec7
 // Yearn vault address: 0x83f798e925BcD4017Eb265844FDDAbb448f1707D
-contract TetherToken is TestERC20Mintable {
-  constructor() ERC20('Funny Tether USD', 'USDT') {
-    // Initialize {ERC20}
-    _setupDecimals(6);
-  }
+contract TetherToken is TestTetherMintable {
+  constructor()
+    TestTetherMintable(100000000000, 'Funny Tether USD', 'USDT', 6)
+  {}
 }


### PR DESCRIPTION
The IERC20 interface does not work for USDT because its implementation does not provide return values for approve and transfer[From]. This PR adds SafeERC20 library implementation which supports optional return values.