### PR TITLE
Applicature fixes

### DIFF
--- a/contracts/0xerc1155/proxy/Initializable.sol
+++ b/contracts/0xerc1155/proxy/Initializable.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+// solhint-disable-next-line compiler-version
+pragma solidity >=0.4.24 <0.8.0;
+
+import '../utils/Address.sol';
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ *
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {UpgradeableProxy-constructor}.
+ *
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+  /**
+   * @dev Indicates that the contract has been initialized.
+   */
+  bool private _initialized;
+
+  /**
+   * @dev Indicates that the contract is in the process of being initialized.
+   */
+  bool private _initializing;
+
+  /**
+   * @dev Modifier to protect an initializer function from being invoked twice.
+   */
+  modifier initializer() {
+    require(
+      _initializing || _isConstructor() || !_initialized,
+      'Initializable: contract is already initialized'
+    );
+
+    bool isTopLevelCall = !_initializing;
+    if (isTopLevelCall) {
+      _initializing = true;
+      _initialized = true;
+    }
+
+    _;
+
+    if (isTopLevelCall) {
+      _initializing = false;
+    }
+  }
+
+  /// @dev Returns true if and only if the function is running in the constructor
+  function _isConstructor() private view returns (bool) {
+    return !Address.isContract(address(this));
+  }
+}

--- a/contracts/src/token/WOWSErc1155.sol
+++ b/contracts/src/token/WOWSErc1155.sol
@@ -10,13 +10,15 @@ pragma solidity >=0.7.0 <0.8.0;
 
 import '@openzeppelin/contracts/proxy/Clones.sol';
 
+import '../../0xerc1155/proxy/Initializable.sol';
+
 import './interfaces/IWOWSCryptofolio.sol';
 import './interfaces/IWOWSERC1155.sol';
 import './WOWSMinterPauser.sol';
 import '../cfolio/interfaces/ICFolioItemHandler.sol';
 import '../utils/TokenIds.sol';
 
-contract WOWSERC1155 is IWOWSERC1155, WOWSMinterPauser {
+contract WOWSERC1155 is Initializable, IWOWSERC1155, WOWSMinterPauser {
   using TokenIds for uint256;
 
   //////////////////////////////////////////////////////////////////////////////
@@ -108,13 +110,7 @@ contract WOWSERC1155 is IWOWSERC1155, WOWSMinterPauser {
     string calldata customMetadataURI,
     string calldata cfolioMetadataURI,
     string calldata contractMetadataURI
-  ) public {
-    // Check for one time initialization
-    require(
-      getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 0,
-      'SFT: Already initialized'
-    );
-
+  ) public initializer {
     // Initialize {AccessControl}
     _setupRole(DEFAULT_ADMIN_ROLE, owner);
 

--- a/contracts/src/token/WOWSMinterPauser.sol
+++ b/contracts/src/token/WOWSMinterPauser.sol
@@ -22,12 +22,7 @@ import '../../0xerc1155/tokens/ERC1155/ERC1155MintBurn.sol';
  * This contract is a replacement for the file ERC1155PresetMinterPauser.sol
  * in the OpenZeppelin project.
  */
-contract WOWSMinterPauser is
-  Context,
-  AccessControl,
-  ERC1155MintBurn,
-  ERC1155Metadata
-{
+contract WOWSMinterPauser is AccessControl, ERC1155MintBurn, ERC1155Metadata {
   //////////////////////////////////////////////////////////////////////////////
   // Roles
   //////////////////////////////////////////////////////////////////////////////

--- a/contracts/src/token/WOWSMinterPauser.sol
+++ b/contracts/src/token/WOWSMinterPauser.sol
@@ -28,7 +28,7 @@ contract WOWSMinterPauser is AccessControl, ERC1155MintBurn, ERC1155Metadata {
   //////////////////////////////////////////////////////////////////////////////
 
   // Role to mint new tokens
-  bytes32 public constant MINTER_ROLE = 'MINTER_ROLE';
+  bytes32 public constant MINTER_ROLE = keccak256('MINTER_ROLE');
 
   //////////////////////////////////////////////////////////////////////////////
   // State


### PR DESCRIPTION
## Description

This PR contains two fixes for the two informational issues surfaced in the Applicature audit.

Link to document: https://docs.google.com/document/d/1scnexzQE1jlhkiLqwa2lZ5t9Xvw7Q08rcn4k9YvOfqc

### 1. Unresolved / Informational: Unnecessary contract inheritance

*Explanation:*

The WOWSMinterPauser inherits Context and AccessControl contracts but AccessControl already inherits Context.
Also regarding this conversation, the use of Context “doesn’t by itself provide any more security”, it should be used in solutions which support meta-transactions or upgradable contracts. Since there is no such mechanic, Context will only use gas instead of providing more security.

*Recommendation:*

Remove Context inheritance from WOWSMinterPauser.

*Implemented solution:*

Unnecessary inheritance has been removed.

### 2. Unresolved / Informational: Using string instead of keccak256 for declaring roles

*Explanation:*

The WOWSMinterPauser uses AccessControl to give access to minting by specific role. To declare a role , use the bytes32 variable which is initialized by string. Since string is a dynamic-size variable and bytes32 is fixed-size it can lead to unpredictable situations.

*Recommendations:*

Use keccak256 instead of string to declare roles for AccessControl.

*Implemented solution:*

keccak256 is now used to declare the minter role.

### 3. Unresolved / Informational: Unused function in WOWSERC1155

*Explanation:*

The WOWSERC1155 contract has an initialization function to set the owner and other variables. It has a check for the count of DEFAULT_ADMIN_ROLE to prevent it from being used more than one time. But DEFAULT_ADMIN_ROLE already has at least one address from the constructor. It means that it can’t be called. Also this function can be called from any address, it means that anyone can set the owner if the first point will be fixed. 

*Recommendations:*

One of three:

* Use OpenZeppelin initializable contract. 
* Use initialize inside constructor call instead of _setupRole
* Remove check for DEFAULT_ADMIN_ROLE count and add onlyOwner modifier.

*Implemented solution:*

The OpenZeppelin initializable contract has been used.

## How has this been tested?

See CI results.